### PR TITLE
Change links to https for freemarker website

### DIFF
--- a/README
+++ b/README
@@ -20,13 +20,13 @@
 Apache FreeMarker Site
 ----------------------
 
-This is the project with which we generate the freemarker.org home page.
+This is the project with which we generate the freemarker.apache.org home page.
 Note that most of the work is done by Apache FreeMarker Docgen, which is
 a dependency of this project.
 
 To publish the built site, commit the output into the "asf-site" branch.
 
 Note that as of this writing, the "docgen" dependency is get from the Ivy
-repo on the published homepage (http://freemarker.org/repos/ivy/). Those
+repo on the published homepage (http://freemarker.apache.org/repos/ivy/). Those
 modifying docgen should upload the fresh docgen jar there. Then you need to
 run `ant update-deps` here to grab the latest version.

--- a/README
+++ b/README
@@ -27,6 +27,6 @@ a dependency of this project.
 To publish the built site, commit the output into the "asf-site" branch.
 
 Note that as of this writing, the "docgen" dependency is get from the Ivy
-repo on the published homepage (http://freemarker.apache.org/repos/ivy/). Those
+repo on the published homepage (https://freemarker.apache.org/repos/ivy/). Those
 modifying docgen should upload the fresh docgen jar there. Then you need to
 run `ant update-deps` here to grab the latest version.

--- a/build.xml
+++ b/build.xml
@@ -95,7 +95,7 @@
   >
     <echo>Getting dependencies...</echo>
     <echo>-------------------------------------------------------</echo>
-    <ivy:settings id="remote" url="http://freemarker.org/repos/ivy/ivysettings-remote.xml" />
+    <ivy:settings id="remote" url="http://freemarker.apache.org/repos/ivy/ivysettings-remote.xml" />
     <!-- Build an own repository that will serve us even offline: -->
     <ivy:retrieve settingsRef="remote" sync="true"
       ivypattern=".ivy.part/repo/[organisation]/[module]/ivy-[revision].xml"
@@ -174,7 +174,7 @@
   
   <!--
     This meant to be called on the Continuous Integration server, so the
-    integration builds appear in the freemarker.org public Ivy repository.
+    integration builds appear in the freemarker.apache.org public Ivy repository.
     The artifacts must be already built.
   -->
   <target name="server-publish-last-build"

--- a/build.xml
+++ b/build.xml
@@ -95,7 +95,7 @@
   >
     <echo>Getting dependencies...</echo>
     <echo>-------------------------------------------------------</echo>
-    <ivy:settings id="remote" url="http://freemarker.apache.org/repos/ivy/ivysettings-remote.xml" />
+    <ivy:settings id="remote" url="https://freemarker.apache.org/repos/ivy/ivysettings-remote.xml" />
     <!-- Build an own repository that will serve us even offline: -->
     <ivy:retrieve settingsRef="remote" sync="true"
       ivypattern=".ivy.part/repo/[organisation]/[module]/ivy-[revision].xml"

--- a/src/main/docgen/book.xml
+++ b/src/main/docgen/book.xml
@@ -164,11 +164,11 @@
     downloading from a mirror please check the checksum and verify the OpenPGP
     compatible signature specified next to the download link (MD5, SHA256 and
     ASC files, all must come from the <link
-    xlink:href="http://www.apache.org/">www.apache.org</link> domain). The
+    xlink:href="https://www.apache.org/">www.apache.org</link> domain). The
     public keys used for signing are here: <link
-    xlink:href="http://www.apache.org/dist/incubator/freemarker/KEYS">KEYS</link>
+    xlink:href="https://www.apache.org/dist/incubator/freemarker/KEYS">KEYS</link>
     (also must come from www.apache.org). <link
-    xlink:href="http://www.apache.org/dyn/closer.cgi#verify">More about how to
+    xlink:href="https://www.apache.org/dyn/closer.cgi#verify">More about how to
     verify releases...</link> Note that such verification is only possible
     since 2.3.24.</para>
 
@@ -194,7 +194,7 @@
       <itemizedlist>
         <listitem>
           <para><link
-          xlink:href="http://www.apache.org/dyn/closer.cgi/incubator/freemarker/engine/2.3.27-incubating/binaries/apache-freemarker-2.3.27-incubating-bin.tar.gz">Binary
+          xlink:href="https://www.apache.org/dyn/closer.cgi/incubator/freemarker/engine/2.3.27-incubating/binaries/apache-freemarker-2.3.27-incubating-bin.tar.gz">Binary
           release (tar.gz)</link> (includes <literal>freemarker.jar</literal>
           and documentation) [<link
           xlink:href="https://www.apache.org/dist/incubator/freemarker/engine/2.3.27-incubating/binaries/apache-freemarker-2.3.27-incubating-bin.tar.gz.md5">MD5</link>]
@@ -206,7 +206,7 @@
 
         <listitem>
           <para><link
-          xlink:href="http://www.apache.org/dyn/closer.cgi/incubator/freemarker/engine/2.3.27-incubating/source/apache-freemarker-2.3.27-incubating-src.tar.gz">Source
+          xlink:href="https://www.apache.org/dyn/closer.cgi/incubator/freemarker/engine/2.3.27-incubating/source/apache-freemarker-2.3.27-incubating-src.tar.gz">Source
           release (tar.gz)</link> [<link
           xlink:href="https://www.apache.org/dist/incubator/freemarker/engine/2.3.27-incubating/source/apache-freemarker-2.3.27-incubating-src.tar.gz.md5">MD5</link>]
           [<link
@@ -244,7 +244,7 @@ two freemarker.jar-s and unpredictable behavior!
 
       <para>There's also a separate Google App Engine compatible
       (<quote>gae</quote>) variation. Download: <link
-      xlink:href="http://www.apache.org/dyn/closer.cgi/incubator/freemarker/engine/2.3.27-incubating/binaries/apache-freemarker-gae-2.3.27-incubating-bin.tar.gz">binary</link>
+      xlink:href="https://www.apache.org/dyn/closer.cgi/incubator/freemarker/engine/2.3.27-incubating/binaries/apache-freemarker-gae-2.3.27-incubating-bin.tar.gz">binary</link>
       [<link
       xlink:href="https://www.apache.org/dist/incubator/freemarker/engine/2.3.27-incubating/binaries/apache-freemarker-gae-2.3.27-incubating-bin.tar.gz.md5">MD5</link>]
       [<link
@@ -252,7 +252,7 @@ two freemarker.jar-s and unpredictable behavior!
       [<link
       xlink:href="https://www.apache.org/dist/incubator/freemarker/engine/2.3.27-incubating/binaries/apache-freemarker-gae-2.3.27-incubating-bin.tar.gz.asc">ASC</link>],
       <link
-      xlink:href="http://www.apache.org/dyn/closer.cgi/incubator/freemarker/engine/2.3.27-incubating/source/apache-freemarker-gae-2.3.27-incubating-src.tar.gz">source</link>
+      xlink:href="https://www.apache.org/dyn/closer.cgi/incubator/freemarker/engine/2.3.27-incubating/source/apache-freemarker-gae-2.3.27-incubating-src.tar.gz">source</link>
       [<link
       xlink:href="https://www.apache.org/dist/incubator/freemarker/engine/2.3.27-incubating/source/apache-freemarker-gae-2.3.27-incubating-src.tar.gz.md5">MD5</link>]
       [<link
@@ -1163,13 +1163,13 @@ two freemarker.jar-s and unpredictable behavior!
         still iterate over it until it becomes good enough for merging.</para>
 
         <para>Note that you will need an <link
-        xlink:href="http://www.apache.org/dev/new-committers-guide.html#cla">Individual
+        xlink:href="https://www.apache.org/dev/new-committers-guide.html#cla">Individual
         Contributor License Agreement (ICLA) or Corporate CLA at the Apache
         Software Foundation</link>, or else we can't merge in your
         contribution.</para>
 
         <para>For more generic guidelines, see <link
-        xlink:href="http://www.apache.org/foundation/getinvolved.html">how to
+        xlink:href="https://www.apache.org/foundation/getinvolved.html">how to
         contribute to Apache projects</link>.</para>
       </section>
 
@@ -1438,7 +1438,7 @@ two freemarker.jar-s and unpredictable behavior!
         and should update this page where they has to deviate from it.</para>
 
         <para>For general info about making releases, please read <link
-        xlink:href="http://www.apache.org/legal/release-policy#archived">http://www.apache.org/legal/release-policy</link>
+        xlink:href="https://www.apache.org/legal/release-policy#archived">https://www.apache.org/legal/release-policy</link>
         and <link
         xlink:href="http://incubator.apache.org/guides/releasemanagement.html">http://incubator.apache.org/guides/releasemanagement.html</link>.
         The FreeMarker-specific additions to those are:</para>
@@ -1712,7 +1712,7 @@ two freemarker.jar-s and unpredictable behavior!
             role="bold">release</emphasis>/incubator/freemarker and commit
             them. (Of course get rid of any voting attempt numbers in the
             directory names.) Now they should appear under <link
-            xlink:href="http://www.apache.org/dist/incubator/freemarker/">http://www.apache.org/dist/incubator/freemarker/</link>.</para>
+            xlink:href="https://www.apache.org/dist/incubator/freemarker/">https://www.apache.org/dist/incubator/freemarker/</link>.</para>
           </listitem>
 
           <listitem>
@@ -1728,7 +1728,7 @@ two freemarker.jar-s and unpredictable behavior!
 
           <listitem>
             <para>Wait 24 hours so that the mirrors get synced. Check <link
-            xlink:href="http://www.apache.org/dist/incubator/freemarker/">http://www.apache.org/dist/incubator/freemarker/</link>
+            xlink:href="https://www.apache.org/dist/incubator/freemarker/">https://www.apache.org/dist/incubator/freemarker/</link>
             and <link
             xlink:href="http://archive.apache.org/dist/">http://archive.apache.org/dist/</link>.
             Check Maven Central repository too (in the case of non-RC
@@ -1737,7 +1737,7 @@ two freemarker.jar-s and unpredictable behavior!
 
           <listitem>
             <para>Delete the non-latest release of each maintained branch from
-            http://www.apache.org/dist/incubator/freemarker/ (Old ones are
+            https://www.apache.org/dist/incubator/freemarker/ (Old ones are
             automatically available on http://archive.apache.org/dist/)</para>
           </listitem>
 

--- a/src/main/docgen/book.xml
+++ b/src/main/docgen/book.xml
@@ -186,7 +186,7 @@
       site</link>.</para>
 
       <para><link
-      xlink:href="http://freemarker.org/docs/versions_2_3_27.html">See what's
+      xlink:href="http://freemarker.apache.org/docs/versions_2_3_27.html">See what's
       new...</link></para>
 
       <para>Downloads:</para>
@@ -1076,7 +1076,7 @@ two freemarker.jar-s and unpredictable behavior!
 
             <tr valign="top">
               <td><link
-              xlink:href="http://freemarker.org">freemarker.org</link></td>
+              xlink:href="http://freemarker.apache.org">freemarker.apache.org</link></td>
 
               <td>Not surprisingly, the pages you view right now are generated
               using FreeMarker.</td>
@@ -1460,7 +1460,7 @@ two freemarker.jar-s and unpredictable behavior!
               <listitem>
                 <para>RC documentation (Manual + JavaDoc) is only published
                 under
-                http://freemarker.org/builds/<replaceable>X.X.X</replaceable>-rc<replaceable>X</replaceable>/</para>
+                http://freemarker.apache.org/builds/<replaceable>X.X.X</replaceable>-rc<replaceable>X</replaceable>/</para>
               </listitem>
             </itemizedlist>
           </listitem>
@@ -1587,7 +1587,7 @@ two freemarker.jar-s and unpredictable behavior!
 
           <listitem>
             <para>Upload the content of <literal>documentation/_html</literal>
-            from the binary release to http://freemarker.org/<emphasis
+            from the binary release to http://freemarker.apache.org/<emphasis
             role="bold">builds/<replaceable>X.X.X</replaceable>-voting</emphasis>/documentation/
             (by committing it into the <quote>asf-site</quote> branch of
             https://git-wip-us.apache.org/repos/asf/incubator-freemarker-site.git).
@@ -1665,7 +1665,7 @@ two freemarker.jar-s and unpredictable behavior!
 
                   <listitem>
                     <para>Link the change log (page under
-                    http://freemarker.org/builds/<replaceable>X.X.X</replaceable>/)</para>
+                    http://freemarker.apache.org/builds/<replaceable>X.X.X</replaceable>/)</para>
                   </listitem>
 
                   <listitem>
@@ -1748,7 +1748,7 @@ two freemarker.jar-s and unpredictable behavior!
           </listitem>
 
           <listitem>
-            <para>Update http://freemarker.org:</para>
+            <para>Update http://freemarker.apache.org:</para>
 
             <itemizedlist>
               <listitem>
@@ -1927,7 +1927,7 @@ two freemarker.jar-s and unpredictable behavior!
         <para>Docgen is not published to the Maven Central Repository, as it's
         only used as an internal build dependency. Currently, it's published
         manually to the internal Ivy repository of the project, which is under
-        http://freemarker.org/repos/ivy/. If you modify Docgen, don't forget
+        http://freemarker.apache.org/repos/ivy/. If you modify Docgen, don't forget
         to publish there, or else the next site update or FreeMarker release
         will use an outdated version. For that:</para>
 
@@ -1939,8 +1939,8 @@ two freemarker.jar-s and unpredictable behavior!
           <listitem>
             <para>Upload the content of the resulting
             <literal>build\dummy-server-ivy-repo</literal> directory to
-            <literal>http://freemarker.org/repos/ivy/</literal>. See how to
-            update the contents of freemarker.org <link
+            <literal>http://freemarker.apache.org/repos/ivy/</literal>. See how to
+            update the contents of freemarker.apache.org <link
             linkend="updating-homepage">here...</link></para>
           </listitem>
 
@@ -2035,7 +2035,7 @@ two freemarker.jar-s and unpredictable behavior!
         </listitem>
 
         <listitem>
-          <para><literal>freemarker-site</literal>: Web site (freemarker.org)
+          <para><literal>freemarker-site</literal>: Web site (freemarker.apache.org)
           contents. URL: <olink targetdoc="gitSite"/>. GitHub mirror: <olink
           targetdoc="githubMirrorSite"/>. Relevant branches:
           <literal>master</literal></para>

--- a/src/main/docgen/book.xml
+++ b/src/main/docgen/book.xml
@@ -275,7 +275,7 @@ two freemarker.jar-s and unpredictable behavior!
       2.2 series. Requires J2SE 1.2 or higher.</para>
 
       <para><link
-      xlink:href="http://prdownloads.sourceforge.net/freemarker/freemarker-2.2.8.tar.gz">Download
+      xlink:href="https://prdownloads.sourceforge.net/freemarker/freemarker-2.2.8.tar.gz">Download
       freemarker-2.2.8.tar.gz</link> (1.4 MB)</para>
     </simplesect>
 
@@ -286,7 +286,7 @@ two freemarker.jar-s and unpredictable behavior!
       2.1 series. Requires J2SE 1.3 or higher.</para>
 
       <para><link
-      xlink:href="http://prdownloads.sourceforge.net/freemarker/freemarker-2.1.5.tar.gz">Download
+      xlink:href="https://prdownloads.sourceforge.net/freemarker/freemarker-2.1.5.tar.gz">Download
       freemarker-2.1.5.tar.gz</link> (909 KB)</para>
     </simplesect>
 
@@ -297,7 +297,7 @@ two freemarker.jar-s and unpredictable behavior!
       series. Requires J2SE 1.2 or higher.</para>
 
       <para><link
-      xlink:href="http://prdownloads.sourceforge.net/freemarker/freemarker2_03.tar.gz">Download
+      xlink:href="https://prdownloads.sourceforge.net/freemarker/freemarker2_03.tar.gz">Download
       freemarker2_03.tar.gz</link> (617 KB)</para>
     </simplesect>
 
@@ -315,7 +315,7 @@ two freemarker.jar-s and unpredictable behavior!
 
       <para>Outdated versions starting from 2.3.24 RC01 are available from the
       Apache archive: <link
-      xlink:href="http://archive.apache.org/dist/incubator/freemarker/engine/">http://archive.apache.org/dist/incubator/freemarker/engine/</link>.
+      xlink:href="https://archive.apache.org/dist/incubator/freemarker/engine/">https://archive.apache.org/dist/incubator/freemarker/engine/</link>.
       Even older releases are available from the <link
       xlink:href="https://sourceforge.net/projects/freemarker/files/freemarker/">SourceForge
       download page</link>.</para>

--- a/src/main/docgen/book.xml
+++ b/src/main/docgen/book.xml
@@ -186,7 +186,7 @@
       site</link>.</para>
 
       <para><link
-      xlink:href="http://freemarker.apache.org/docs/versions_2_3_27.html">See what's
+      xlink:href="https://freemarker.apache.org/docs/versions_2_3_27.html">See what's
       new...</link></para>
 
       <para>Downloads:</para>
@@ -1076,7 +1076,7 @@ two freemarker.jar-s and unpredictable behavior!
 
             <tr valign="top">
               <td><link
-              xlink:href="http://freemarker.apache.org">freemarker.apache.org</link></td>
+              xlink:href="https://freemarker.apache.org">freemarker.apache.org</link></td>
 
               <td>Not surprisingly, the pages you view right now are generated
               using FreeMarker.</td>
@@ -1460,7 +1460,7 @@ two freemarker.jar-s and unpredictable behavior!
               <listitem>
                 <para>RC documentation (Manual + JavaDoc) is only published
                 under
-                http://freemarker.apache.org/builds/<replaceable>X.X.X</replaceable>-rc<replaceable>X</replaceable>/</para>
+                https://freemarker.apache.org/builds/<replaceable>X.X.X</replaceable>-rc<replaceable>X</replaceable>/</para>
               </listitem>
             </itemizedlist>
           </listitem>
@@ -1587,7 +1587,7 @@ two freemarker.jar-s and unpredictable behavior!
 
           <listitem>
             <para>Upload the content of <literal>documentation/_html</literal>
-            from the binary release to http://freemarker.apache.org/<emphasis
+            from the binary release to https://freemarker.apache.org/<emphasis
             role="bold">builds/<replaceable>X.X.X</replaceable>-voting</emphasis>/documentation/
             (by committing it into the <quote>asf-site</quote> branch of
             https://git-wip-us.apache.org/repos/asf/incubator-freemarker-site.git).
@@ -1665,7 +1665,7 @@ two freemarker.jar-s and unpredictable behavior!
 
                   <listitem>
                     <para>Link the change log (page under
-                    http://freemarker.apache.org/builds/<replaceable>X.X.X</replaceable>/)</para>
+                    https://freemarker.apache.org/builds/<replaceable>X.X.X</replaceable>/)</para>
                   </listitem>
 
                   <listitem>
@@ -1748,7 +1748,7 @@ two freemarker.jar-s and unpredictable behavior!
           </listitem>
 
           <listitem>
-            <para>Update http://freemarker.apache.org:</para>
+            <para>Update https://freemarker.apache.org:</para>
 
             <itemizedlist>
               <listitem>
@@ -1927,7 +1927,7 @@ two freemarker.jar-s and unpredictable behavior!
         <para>Docgen is not published to the Maven Central Repository, as it's
         only used as an internal build dependency. Currently, it's published
         manually to the internal Ivy repository of the project, which is under
-        http://freemarker.apache.org/repos/ivy/. If you modify Docgen, don't forget
+        https://freemarker.apache.org/repos/ivy/. If you modify Docgen, don't forget
         to publish there, or else the next site update or FreeMarker release
         will use an outdated version. For that:</para>
 
@@ -1939,7 +1939,7 @@ two freemarker.jar-s and unpredictable behavior!
           <listitem>
             <para>Upload the content of the resulting
             <literal>build\dummy-server-ivy-repo</literal> directory to
-            <literal>http://freemarker.apache.org/repos/ivy/</literal>. See how to
+            <literal>https://freemarker.apache.org/repos/ivy/</literal>. See how to
             update the contents of freemarker.apache.org <link
             linkend="updating-homepage">here...</link></para>
           </listitem>

--- a/src/main/docgen/docgen.cjson
+++ b/src/main/docgen/docgen.cjson
@@ -17,7 +17,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-deployUrl: "http://freemarker.apache.org/"
+deployUrl: "https://freemarker.apache.org/"
 onlineTrackerHTML: "docgen-misc/googleAnalytics.html"
 offline: false
 simpleNavigationMode

--- a/src/main/docgen/docgen.cjson
+++ b/src/main/docgen/docgen.cjson
@@ -44,7 +44,7 @@ seoMeta: {
 }
 
 logo: {
-  href: "http://freemarker.apache.org/"
+  href: "https://freemarker.apache.org/"
   src: logo.png
   alt: "FreeMarker"
 }

--- a/src/main/docgen/sitemap-index.xml
+++ b/src/main/docgen/sitemap-index.xml
@@ -19,11 +19,11 @@
 -->
  <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
    <sitemap>
-      <loc>http://www.freemarker.org/sitemap.xml</loc>
+      <loc>http://freemarker.apache.org/sitemap.xml</loc>
       <lastmod>2015-07-20</lastmod>
    </sitemap>
    <sitemap>
-      <loc>http://www.freemarker.org/docs/sitemap.xml</loc>
+      <loc>http://freemarker.apache.org/docs/sitemap.xml</loc>
       <lastmod>2015-07-20</lastmod>
    </sitemap>
  </sitemapindex>

--- a/src/main/docgen/sitemap-index.xml
+++ b/src/main/docgen/sitemap-index.xml
@@ -19,11 +19,11 @@
 -->
  <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
    <sitemap>
-      <loc>http://freemarker.apache.org/sitemap.xml</loc>
+      <loc>https://freemarker.apache.org/sitemap.xml</loc>
       <lastmod>2015-07-20</lastmod>
    </sitemap>
    <sitemap>
-      <loc>http://freemarker.apache.org/docs/sitemap.xml</loc>
+      <loc>https://freemarker.apache.org/docs/sitemap.xml</loc>
       <lastmod>2015-07-20</lastmod>
    </sitemap>
  </sitemapindex>


### PR DESCRIPTION
- Change all freemarker.org to freemarker.apache.org
- Change all internal links to https
- Change all www.apache.org links to https, except of license files.
- Change some external urls, available with https.