### PR TITLE
chore: Delete DISCLAIMER

### DIFF
--- a/DISCLAIMER
+++ b/DISCLAIMER
@@ -1,8 +1,0 @@
-Apache FreeMarker Site is an effort undergoing incubation at The Apache
-Software Foundation (ASF), sponsored by the Apache Incubator. Incubation
-is required of all newly accepted projects until a further review indicates
-that the infrastructure, communications, and decision making process have
-stabilized in a manner consistent with other successful ASF projects. While
-incubation status is not necessarily a reflection of the completeness or
-stability of the code, it does indicate that the project has yet to be fully
-endorsed by the ASF.


### PR DESCRIPTION
Since Apache Freemarker has been a TLP, the DISCLAIMER could be removed.